### PR TITLE
flash_all: #!/usr/bin/env bash is generally considered better for portability.

### DIFF
--- a/template/flash_all.sh
+++ b/template/flash_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Flasher script for Droidian images
 # Copyright (C) 2022-2024 Eugenio "g7" Paolantonio <me@medesimo.eu>


### PR DESCRIPTION
I am using NixOS where bash isn't on `/bin/bash`, hence the script didn't run. So,

`#!/usr/bin/env bash`:

- This uses the env command to find the Bash interpreter in the user's PATH. It searches for bash in the directories listed in the PATH environment variable and uses the first one it finds.
- This method is more portable because it does not assume a specific location for the Bash interpreter. It will work as long as Bash is installed and available in the user's PATH.

